### PR TITLE
Better randomization of centroids

### DIFF
--- a/km.go
+++ b/km.go
@@ -48,6 +48,8 @@ type CentroidChooser interface {
 
 type RandCentroids struct {}
 
+type DataCentroids struct {}
+
 // Load loads a tab delimited text file of floats into a slice.
 // Assume last column is the target.
 // For now, we limit ourselves to two columns
@@ -141,6 +143,23 @@ func (c RandCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 			randInRange := ((maxj - minj) * rand.Float64()) + minj
 			centroids.Set(h, colnum, randInRange)
 		}
+	}
+	return centroids
+}
+
+func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.DenseMatrix {
+	// first set up a map to keep track of which data points have already been chosen so we don't dupe
+	rows, cols := mat.GetSize()
+	chosenIdxs := make(map [int]bool, k)
+	for len(chosenIdxs) < k {
+		index := rand.Intn(rows)
+		k[index] = true // d'oh, it doesn't like this
+	}
+	centroids := matrix.Zeros(k, cols)
+	i := 0
+	for idx, _ := range chosenIdxs {
+		matutil.SetRowVector(centroids, mat.GetRowVector(idx).Copy(), i)
+		i += 1
 	}
 	return centroids
 }

--- a/km.go
+++ b/km.go
@@ -137,23 +137,9 @@ func (c RandCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 
 		// create a slice of random centroids 
 		// based on maxj + minJ * random num to stay in range
-		// TODO: Better randomization or choose centroids 
-		// from datapoints.
-		rands := make([]float64, k)
-		for i := 0; i < k; i++ {
-			randint := float64(rand.Int())
-			rf := (maxj - minj) * randint
-			for rf > maxj {
-				if rf > maxj*3 {
-					rf = rf / maxj
-				} else {
-					rf = rf / 3.14
-				}
-			}
-			rands[i] = rf
-		}
 		for h := 0; h < k; h++ {
-			centroids.Set(h, colnum, rands[h])
+			randInRange := ((maxj - minj) * rand.Float64()) + minj
+			centroids.Set(h, colnum, randInRange)
 		}
 	}
 	return centroids

--- a/km.go
+++ b/km.go
@@ -46,8 +46,10 @@ type CentroidChooser interface {
 	ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.DenseMatrix
 }
 
+// RandCentroids picks k uniformly distributed points from within the bounds of the dataset
 type RandCentroids struct {}
 
+// DataCentroids picks k distinct points from the dataset
 type DataCentroids struct {}
 
 // Load loads a tab delimited text file of floats into a slice.
@@ -153,7 +155,7 @@ func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 	chosenIdxs := make(map [int]bool, k)
 	for len(chosenIdxs) < k {
 		index := rand.Intn(rows)
-		k[index] = true // d'oh, it doesn't like this
+		chosenIdxs[index] = true 
 	}
 	centroids := matrix.Zeros(k, cols)
 	i := 0

--- a/km.go
+++ b/km.go
@@ -52,6 +52,11 @@ type RandCentroids struct {}
 // DataCentroids picks k distinct points from the dataset
 type DataCentroids struct {}
 
+// EllipseCentroids lays out the centroids along an elipse inscribed within the boundaries of the dataset
+type EllipseCentroids struct {
+	frac float // must be btw 0 and 1, this will be what fraction of a truly inscribing ellipse this is
+}
+
 // Load loads a tab delimited text file of floats into a slice.
 // Assume last column is the target.
 // For now, we limit ourselves to two columns
@@ -165,6 +170,21 @@ func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 	}
 	return centroids
 }
+
+func (c EllipseCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.DenseMatrix {
+	rows, cols := mat.GetSize()
+	var xmin, xmax, ymin, ymax float64 // TODO - fxn to get these from the data matrix
+	x0, y0 := xmin + (xmax - xmin)/2.0, ymin + (ymax-ymin)/2.0
+	centroids := matrix.Zeros(k, cols)
+	rx, ry := xmax - x0, ymax - y0  
+	thetaInit := rand.Float64() * math.Pi
+	for i := 0; i < k; i++ {
+		centroids.Set(i, 0, r0 * c.frac * math.Cos(thetaInit + i * math.Pi / k))
+		centroids.Set(i, 1, r1 * c.frac * math.Sin(thetaInit + i * math.Pi / k))		
+	}
+	return centroids
+}
+
 
 // ComputeCentroids Needs comments.
 func ComputeCentroid(mat *matrix.DenseMatrix) (*matrix.DenseMatrix, error) {

--- a/km_test.go
+++ b/km_test.go
@@ -79,15 +79,17 @@ func TestValidReturnLoad(t *testing.T) {
 func TestRandCentroids(t *testing.T) {
 	rows := 3
 	cols := 3
-	k := 4
+	k := 2
 	data := []float64{1, 2.0, 3, -4.945, 5, -6.1, 7, 8, 9}
 	mat := matrix.MakeDenseMatrix(data, rows, cols)
-	cc := new(RandCentroids)
-	centroids := cc.ChooseCentroids(mat, k)
+	choosers := []CentroidChooser{RandCentroids{}, DataCentroids{}, EllipseCentroids{0.5}}
+	for _, cc := range choosers{
+		centroids := cc.ChooseCentroids(mat, k)
 
-	r, c := centroids.GetSize()
-	if r != k || c != cols {
-		t.Errorf("Returned centroid was %dx%d instead of %dx%d", r, c, rows, cols)
+		r, c := centroids.GetSize()
+		if r != k || c != cols {
+			t.Errorf("Returned centroid was %dx%d instead of %dx%d", r, c, rows, cols)
+		}
 	}
 }
 

--- a/matutil/manip.go
+++ b/matutil/manip.go
@@ -62,3 +62,31 @@ func SetRowVector(target, vector *matrix.DenseMatrix, row int) {
 	target.Set(row, 0, c0)
 	target.Set(row, 1, c1)
 }
+
+// GetBoundaries returns the max and min x and y values for a dense matrix
+// of shape m x 2.
+func GetBoundaries(mat *matrix.DenseMatrix) (xmin, xmax, ymin, ymax float64) {
+	rows, cols := mat.GetSize()
+	if cols != 2 {
+		// TODO - should there be an err return, or should we panic here?
+	}
+	xmin, ymin = mat.Get(0,0), mat.Get(0,1)
+	xmax, ymax = mat.Get(0,0), mat.Get(0,1)
+	for i := 1; i < rows; i++ {
+		xi, yi := mat.Get(i, 0), mat.Get(i, 1)
+		
+		if xi > xmax{
+			xmax = xi
+		} else if xi < xmin {
+			xmin = xi
+		}
+
+		if yi > ymax{
+			ymax = yi
+		} else if yi < ymin {
+			ymin = yi
+		}
+	}
+	return
+}
+

--- a/matutil/manip_test.go
+++ b/matutil/manip_test.go
@@ -5,150 +5,8 @@ import (
 //	"fmt"
 	"testing"
 	"math"
-	"code.google.com/p/gomatrix/matrix"
+	"github.com/bobhancock/gomatrix/matrix"
 )
-
-func TestColSliceValid(t *testing.T) {
-	rows := 3
-	columns := 2
-	mat := matrix.MakeDenseMatrix([]float64{1, 2, 3, 4, 5, 6}, rows, columns)
-	c := ColSlice(mat, 1)
-	if len(c) != rows {
-		t.Errorf("Returned slice has len=%d instead of %d.", len(c), rows)
-	}
-}
-
-func TestAppendColInvalid(t *testing.T) {
-	rows := 3
-	columns := 2
-	mat := matrix.MakeDenseMatrix([]float64{1, 2, 3, 4, 5, 6}, rows, columns)
-	col := []float64{1.1, 2.2, 3.3, 4.4}
-	mat, err := AppendCol(mat, col)
-	if err == nil {
-		t.Errorf("AppendCol err=%v", err)
-	}
-}
-
-func TestAppendColValid(t *testing.T) {
-	rows := 3
-	columns := 2
-	mat := matrix.MakeDenseMatrix([]float64{1, 2, 3, 4, 5, 6}, rows, columns)
-	col := []float64{1.1, 2.2, 3.3}
-	mat, err := AppendCol(mat, col)
-	if err != nil {
-		t.Errorf("AppendCol err=%v", err)
-	}
-}
-
-func TestPow(t *testing.T) {
-	p00 := float64(3)
-	p01 := float64(4)
-	mat := matrix.MakeDenseMatrix([]float64{p00, p01}, 1, 2)
-	raised := Pow(mat, 2)
-
-	r00 := raised.Get(0, 0)
-	if r00 != 9 {
-		t.Errorf("TestPow r00 should be 9, but is %f", r00)
-	}
-	r01 := raised.Get(0, 1)
-	if r01 != 16 {
-		t.Errorf("TestPow r01 should be 16, but is %f", r01)
-	}
-}
-
-func TestSumRows(t *testing.T) {
-	p00 := 3.0
-	p01 := 4.0
-	p10 := 3.5
-	p11 := 4.6
-	mat := matrix.MakeDenseMatrix([]float64{p00, p01, p10, p11}, 2, 2)
-	sums := SumRows(mat)
-
-	numRows, numCols := sums.GetSize()
-	if numRows != 2 || numCols != 1 {
-		t.Errorf("SumRows returned a %dx%d matrix.  It should be 2x1.", numRows, numCols)
-	}
-	s00 := sums.Get(0, 0)
-	if s00 != (p00 + p01) {
-		t.Errorf("SumRows row 0 col 0 is %d.  It should be %d.", s00, p00+p01)
-	}
-	s10 := sums.Get(1, 0)
-	if s10 != (p10 + p11) {
-		t.Errorf("SumRows row 1 col 2 is %d.  It should be %d.", s10, p10+p11)
-	}
-}
-
-func TestSumCols(t *testing.T) {
-	p00 := 3.0
-	p01 := 4.0
-	p10 := 3.5
-	p11 := 4.6
-	mat := matrix.MakeDenseMatrix([]float64{p00, p01, p10, p11}, 2, 2)
-	sums := SumCols(mat)
-
-	numRows, numCols := sums.GetSize()
-	if numRows != 1 || numCols != 2 {
-		t.Errorf("SumCols returned a %dx%d matrix.  It should be 1x2.", numRows, numCols)
-	}
-	s00 := sums.Get(0, 0)
-	if s00 != (p00 + p10) {
-		t.Errorf("SumCols row 0 col 0 is %d.  It should be %d.", s00, p00+p10)
-	}
-	s10 := sums.Get(0, 1)
-	if s10 != (p01 + p11) {
-		t.Errorf("SumCols row 0 col 1 is %d.  It should be %d.", s10, p01+p11)
-	}
-}
-
-func TestFiltCol(t *testing.T) {
-	mat := matrix.MakeDenseMatrix([]float64{2, 1, 4, 2, 6, 3, 8, 4, 10, 5, 1, 1}, 5, 2)
-	// mat, max, min, column
-	matches, err := FiltCol(mat, 2.0, 4.0, 1)
-	if err != nil {
-		t.Errorf("FiltCol returned error: %v", err)
-		return
-	}
-	r, _ := matches.GetSize()
-	if r != 3 {
-		t.Errorf("FiltCol: expected 3 rows and got %d", r)
-	}
-
-	m0 := matches.Get(0,1)
-	if m0 != float64(2) {
-		t.Errorf("FiltCol: expected row 0 col 1 to be 2, but got %f",m0)
-	}
-
-	m1 := matches.Get(1, 1)
-	if m1 != 3 {
-		t.Errorf("FiltCol: expected row 1 col 1 to be 3, but got %f",m1)
-	}
-
-	m2 := matches.Get(2, 1)
-	if m2 !=4 {
-		t.Errorf("FiltCol: expected row 1 col 1 to be 3, but got %f",m2)
-	}
-	matches, err = FiltCol(mat, 100.0, 200.00, 1)
-	if err == nil {
-		t.Errorf("FiltCol did not return err on no match condition.")
-	}
-}
-
-func TestFiltColMap(t *testing.T) {
-	mat := matrix.MakeDenseMatrix([]float64{2, 1, 4, 2, 6, 3,8, 4, 10, 5, 1, 1}, 5, 2)
-	matches, err := FiltColMap(mat, 2.0, 4.0, 1)
-	if err != nil {
-		t.Errorf("FiltColMap returned error: %v", err)
-		return
-	}
-
-	if len(matches) != 3 {
-		t.Errorf("FiltColMap expecte a map of len 3, but got len %d", len(matches))
-	}
-
-	if matches[1] != 2 || matches[2] != 3 || matches[3] != 4 {
-		t.Errorf("FiltColMap expected a map with vals 2, 3, 4 but got %v", matches)
-	}
-}
 
 
 func TestEuclidDist(t *testing.T) {
@@ -205,3 +63,25 @@ func TestManhattanDist(t *testing.T) {
 	}
 }
 //TODO: test for MeanCols
+
+func TestGetBoundaries(t *testing.T) {
+	// first test with single point
+	rows := 1
+	columns := 2
+
+	a := matrix.MakeDenseMatrix([]float64{4.6, 9.5}, rows, columns)
+	xmin, xmax, ymin, ymax := GetBoundaries(a)
+	if xmin != 4.6 || xmax != 4.6 || ymin != 9.5 || ymax != 9.5 {
+		t.Errorf("GetBoundaries failed on single item matrix")
+	}
+
+	b := matrix.MakeDenseMatrix([]float64{3.0, 4.1}, rows, columns)
+	c, err := a.Stack(b)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	xmin, xmax, ymin, ymax = GetBoundaries(c)
+	if xmin != 3.0 || xmax != 4.6 || ymin != 4.1 || ymax != 9.5 {
+		t.Errorf("GetBoundaries failed on two item matrix")
+	}
+}


### PR DESCRIPTION
The current method results in centroids that are too close.  Randomize a spread across the domain of datapoints.
