### PR TITLE
Cc tests

### DIFF
--- a/km.go
+++ b/km.go
@@ -206,15 +206,15 @@ func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 // EllipseCentroids lays out the centroids along an elipse inscribed within the boundaries of the dataset
 func (c EllipseCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.DenseMatrix {
 	_, cols := mat.GetSize()
-	var xmin, xmax, ymin, ymax = matutil.GetBoundaries(mat) 
+	var xmin, xmax, ymin, ymax = matutil.GetBoundaries(mat)
 	x0, y0 := xmin + (xmax - xmin)/2.0, ymin + (ymax-ymin)/2.0
 	centroids := matrix.Zeros(k, cols)
 	rx, ry := xmax - x0, ymax - y0  
 	thetaInit := rand.Float64() * math.Pi
 
 	for i := 0; i < k; i++ {
-		centroids.Set(i, 0, rx * c.frac * math.Cos(thetaInit + float64(i) * math.Pi / float64(k)))
-		centroids.Set(i, 1, ry * c.frac * math.Sin(thetaInit + float64(i) * math.Pi / float64(k)))
+		centroids.Set(i, 0, rx * c.frac * math.Cos(thetaInit + float64(i) * 2.0 * math.Pi / float64(k)))
+		centroids.Set(i, 1, ry * c.frac * math.Sin(thetaInit + float64(i) * 2.0 * math.Pi / float64(k)))
 	}
 	return centroids
 }

--- a/km.go
+++ b/km.go
@@ -185,13 +185,10 @@ func (c RandCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.D
 }
 
 // DataCentroids picks k distinct points from the dataset
-func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) (*matrix.DenseMatrix, error) {
+func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) *matrix.DenseMatrix {
 	// first set up a map to keep track of which data points have already been chosen so we don't dupe
 	rows, cols := mat.GetSize()
 	centroids := matrix.Zeros(k, cols)
-	if k > rows {
-		return centroids, errors.New("ChooseCentroids: Can't compute more centroids than data points!")
-	}
 
 	chosenIdxs := make(map [int]bool, k)
 	for len(chosenIdxs) < k {
@@ -203,7 +200,7 @@ func (c DataCentroids) ChooseCentroids(mat *matrix.DenseMatrix, k int) (*matrix.
 		centroids.SetRowVector(mat.GetRowVector(idx).Copy(), i)
 		i += 1
 	}
-	return centroids, nil
+	return centroids
 }
 
 // EllipseCentroids lays out the centroids along an elipse inscribed within the boundaries of the dataset

--- a/km_test.go
+++ b/km_test.go
@@ -127,7 +127,6 @@ func TestValidReturnLoad(t *testing.T) {
 	}
 }
 
-/* Test fails
 func TestRandCentroids(t *testing.T) {
 	rows := 3
 	cols := 3
@@ -144,7 +143,7 @@ func TestRandCentroids(t *testing.T) {
 		}
 	}
 }
-*/
+
 
 
 func TestComputeCentroid(t *testing.T) {

--- a/km_test.go
+++ b/km_test.go
@@ -142,6 +142,20 @@ func TestRandCentroids(t *testing.T) {
 			t.Errorf("Returned centroid was %dx%d instead of %dx%d", r, c, rows, cols)
 		}
 	}
+
+	// This section of the test places ellipse centroids at fraction 1 on a 2x2 box,
+	// and asserts that there is a distance of 2 between them (ie, they are diametrically opposite)
+	data2 := []float64{1.0, 1.0, -1.0, -1.0}
+	mat2 := matrix.MakeDenseMatrix(data2, 2, 2)
+	newCentroids := EllipseCentroids{1.0}.ChooseCentroids(mat2, 2)
+	dist := matutil.EuclidDist{}.CalcDist(newCentroids.GetRowVector(0), newCentroids.GetRowVector(1))
+	expectedEd := 2.0 //expected value
+	epsilon := .000001
+	diff := math.Abs(dist - expectedEd)
+	if diff > epsilon {
+		t.Errorf("EuclidDist: excpected %f but received %f.  The difference %f exceeds epsilon %f", expectedEd, dist, diff, epsilon)
+	}
+
 }
 
 


### PR DESCRIPTION
This fixes an error causing TestRandCentroids to fail (namely, that DataCentroids had the wrong return type), and also fixes a factor-of-two error in Ellipse Centroids and adds a test to cover that error
